### PR TITLE
Initialize AlertPatch with empty tripPatterns on stop centric alerts …

### DIFF
--- a/src/main/java/org/opentripplanner/routing/alertpatch/AlertPatch.java
+++ b/src/main/java/org/opentripplanner/routing/alertpatch/AlertPatch.java
@@ -145,6 +145,7 @@ public class AlertPatch implements Serializable {
                     break;
                 }
             }
+            tripPatterns = emptyList();
         } else if (agency != null) {
             tripPatterns = graph.index.patternsForAgency.get(agency);
             for (TripPattern tripPattern : tripPatterns) {


### PR DESCRIPTION
…to avoid getTripPatterns() throwing NullPointerExeception

Code is queried from GraphQL via GraphIndex -> getAlertsForPattern()