### PR TITLE
Fix graphql route type

### DIFF
--- a/src/main/java/org/opentripplanner/index/IndexGraphQLSchema.java
+++ b/src/main/java/org/opentripplanner/index/IndexGraphQLSchema.java
@@ -1337,6 +1337,9 @@ public class IndexGraphQLSchema {
             .field(GraphQLFieldDefinition.newFieldDefinition()
                 .name("type")
                 .type(Scalars.GraphQLString)
+                .dataFetcher(environment -> GtfsLibrary.getTraverseMode(
+                    (Route) environment.getSource())) //TODO: Remove the data fetcher to export proper type when upgrading to v2 of the HSL scheme
+                .deprecate("The meaning of the type field will be changed to v2. Please use the mode-field instead. Type will export the raw type integer form the GTFS source.")
                 .build())
             .field(GraphQLFieldDefinition.newFieldDefinition()
                 .name("desc")


### PR DESCRIPTION
This reverts change in upstream OTP, which changes our API. It marks the field as deprecated, so that we can change it to match the upstream behaviour in v2.