### PR TITLE
feat: use walking meters instead of seconds

### DIFF
--- a/src/main/java/org/opentripplanner/routing/graph/GraphIndex.java
+++ b/src/main/java/org/opentripplanner/routing/graph/GraphIndex.java
@@ -576,7 +576,7 @@ public class GraphIndex {
         }
         @Override public void visitVertex(State state) {
             Vertex vertex = state.getVertex();
-            int distance = (int)state.getElapsedTimeSeconds();
+            int distance = (int)state.getWalkDistance();
             if (vertex instanceof TransitStop) {
                 visitStop(((TransitStop)vertex).getStop(), distance);
             } else if (vertex instanceof BikeRentalStationVertex) {


### PR DESCRIPTION
The previous solution was to try to use 1 m/s speed
and then use seconds. Now since we are walking we can also use
walking distance which gives more consistent result with stairs,
slopes and lifts compared to the regular routing distances.