### PR TITLE
Fix OptimizeType enum name

### DIFF
--- a/src/main/java/org/opentripplanner/index/IndexGraphQLSchema.java
+++ b/src/main/java/org/opentripplanner/index/IndexGraphQLSchema.java
@@ -154,7 +154,7 @@ public class IndexGraphQLSchema {
         .build();
 
     public static GraphQLEnumType optimizeTypeEnum = GraphQLEnumType.newEnum()
-        .name("OptimizeTtpe")
+        .name("OptimizeType")
         .value("QUICK", OptimizeType.QUICK, "QUICK")
         .value("SAFE", OptimizeType.SAFE, "SAFE")
         .value("FLAT", OptimizeType.FLAT, "FLAT")


### PR DESCRIPTION
The change is non-breaking as the type names are not used in either
queries or responses