### PR TITLE
DT-1759 Add penalty for walking on roads

### DIFF
--- a/src/main/java/org/opentripplanner/routing/edgetype/StreetEdge.java
+++ b/src/main/java/org/opentripplanner/routing/edgetype/StreetEdge.java
@@ -377,6 +377,11 @@ public class StreetEdge extends Edge implements Cloneable {
                 double elevationUtilsSpeed = 4.0 / 3.0;
                 weight = costs * (elevationUtilsSpeed / speed);
                 time = weight; //treat cost as time, as in the current model it actually is the same (this can be checked for maxSlope == 0)
+
+                if (getPermission().allows(TraverseMode.CAR)) {
+                    weight *= 1.5; // Add 50% weight on edges allowed for cars, in order to prefer walkways
+                }
+
                 /*
                 // debug code
                 if(weight > 100){


### PR DESCRIPTION
The penalty needs to be quite big for this to work properly, as the
detours are usually quite long compared to the shorter distance by
road. Also, does not work on one-way streets, with reverse traffic.