### PR TITLE
Accept oulu trip updates

### DIFF
--- a/src/main/java/org/opentripplanner/routing/edgetype/Timetable.java
+++ b/src/main/java/org/opentripplanner/routing/edgetype/Timetable.java
@@ -428,7 +428,7 @@ public class Timetable implements Serializable {
                     } else {
                         long today = updateServiceDate.getAsDate(timeZone).getTime() / 1000;
 
-                        if (update.hasArrival()) {
+                        if (update.hasArrival() && (update.getArrival().hasTime() || update.getArrival().hasDelay())) {
                             StopTimeEvent arrival = update.getArrival();
                             if (arrival.hasDelay()) {
                                 delay = arrival.getDelay();
@@ -454,7 +454,7 @@ public class Timetable implements Serializable {
                             }
                         }
 
-                        if (update.hasDeparture()) {
+                        if (update.hasDeparture() && (update.getDeparture().hasTime() || update.getDeparture().hasDelay())) {
                             StopTimeEvent departure = update.getDeparture();
                             if (departure.hasDelay()) {
                                 delay = departure.getDelay();


### PR DESCRIPTION
It's legal for StopTimeEvents to lack both delay and time, but then no data remains and it's same as no StopTimeEvent at all.