### PR TITLE
DT-2019

### DIFF
--- a/src/main/java/org/opentripplanner/routing/vertextype/BikeRentalStationVertex.java
+++ b/src/main/java/org/opentripplanner/routing/vertextype/BikeRentalStationVertex.java
@@ -30,12 +30,6 @@ public class BikeRentalStationVertex extends Vertex {
 
     private static final long serialVersionUID = MavenVersion.VERSION.getUID();
 
-    private int bikesAvailable;
-
-    private int spacesAvailable;
-
-    private String id;
-    
     private BikeRentalStation station;
 
     public BikeRentalStationVertex(Graph g, BikeRentalStation station) {
@@ -43,33 +37,26 @@ public class BikeRentalStationVertex extends Vertex {
         super(g, "bike rental station " + station.id, station.x, station.y,
                 station.name);
         this.station = station;
-        this.setId(station.id);
-        this.setBikesAvailable(station.bikesAvailable);
-        this.setSpacesAvailable(station.spacesAvailable);
     }
 
     public int getBikesAvailable() {
-        return bikesAvailable;
+        return station.bikesAvailable;
     }
 
     public int getSpacesAvailable() {
-        return spacesAvailable;
+        return station.spacesAvailable;
     }
 
     public void setBikesAvailable(int bikes) {
-        this.bikesAvailable = bikes;
+        station.bikesAvailable = bikes;
     }
 
     public void setSpacesAvailable(int spaces) {
-        this.spacesAvailable = spaces;
+        station.spacesAvailable = spaces;
     }
 
     public String getId() {
-        return id;
-    }
-
-    public void setId(String id) {
-        this.id = id;
+        return station.id;
     }
 
     public BikeRentalStation getStation() {


### PR DESCRIPTION
We seem to use the BikeRentalStation instance of the BikeRentalStationVertex which was not kept in sync with the other instance(s) of the BikeRentalStation. 

There should probably be no such data duplication at all but for now this should fix the bug.
 