### PR TITLE
Fix OSM ways containing bike rental or parking nodes missing from graph

### DIFF
--- a/src/main/java/org/opentripplanner/graph_builder/module/osm/OSMDatabase.java
+++ b/src/main/java/org/opentripplanner/graph_builder/module/osm/OSMDatabase.java
@@ -184,11 +184,9 @@ public class OSMDatabase implements OpenStreetMapContentHandler {
     public void addNode(OSMNode node) {
         if (node.isBikeRental()) {
             bikeRentalNodes.put(node.getId(), node);
-            return;
         }
         if (node.isBikeParking()) {
             bikeParkingNodes.put(node.getId(), node);
-            return;
         }
         if (!(waysNodeIds.contains(node.getId()) || areaNodeIds.contains(node.getId()) || node
                 .isStop()))


### PR DESCRIPTION
Add bike rental and parking nodes to nodesById to prevent dropping ways containing bike rental or parking node