### PR TITLE
Fix compactLegsByReversedSearch default value and updaters crashing

### DIFF
--- a/src/main/java/org/opentripplanner/index/IndexGraphQLSchema.java
+++ b/src/main/java/org/opentripplanner/index/IndexGraphQLSchema.java
@@ -663,7 +663,6 @@ public class IndexGraphQLSchema {
                 .name("compactLegsByReversedSearch")
                 .description("Whether legs should be compacted by performing a reversed search. Experimental argument, will be removed!.")
                 .type(Scalars.GraphQLBoolean)
-                .defaultValue(true)
                 .build())
             .dataFetcher(environment -> new GraphQlPlanner(index).plan(environment))
             .build();

--- a/src/main/java/org/opentripplanner/routing/core/RoutingRequest.java
+++ b/src/main/java/org/opentripplanner/routing/core/RoutingRequest.java
@@ -369,7 +369,7 @@ public class RoutingRequest implements Cloneable, Serializable {
     /**
      * When true, do a full reversed search to compact the legs of the GraphPath.
      */
-    public boolean compactLegsByReversedSearch = false;
+    public boolean compactLegsByReversedSearch = true;
 
     /**
      * If true, cost turns as they would be in a country where driving occurs on the right; otherwise, cost them as they would be in a country where

--- a/src/main/java/org/opentripplanner/routing/graph/Graph.java
+++ b/src/main/java/org/opentripplanner/routing/graph/Graph.java
@@ -753,7 +753,7 @@ public class Graph implements Serializable {
             // vertex list is transient because it can be reconstructed from edges
             LOG.debug("Loading edges...");
             List<Edge> edges = (ArrayList<Edge>) in.readObject();
-            graph.vertices = new HashMap<String, Vertex>();
+            graph.vertices = new ConcurrentHashMap<String, Vertex>();
             
             for (Edge e : edges) {
                 graph.vertices.put(e.getFromVertex().getLabel(), e.getFromVertex());

--- a/src/test/java/org/opentripplanner/graph_builder/module/osm/TestIntermediatePlaces.java
+++ b/src/test/java/org/opentripplanner/graph_builder/module/osm/TestIntermediatePlaces.java
@@ -139,6 +139,7 @@ public class TestIntermediatePlaces {
         request.maxTransfers = 4;
         request.from = from;
         request.to = to;
+        request.compactLegsByReversedSearch = false;
         for (GenericLocation intermediateLocation : via) {
             request.addIntermediatePlace(intermediateLocation);
         }


### PR DESCRIPTION
- Fix `compactLegsByReversedSearch` being true by default
- Try to fix `ConcurrentModificationException` in updaters