### PR TITLE
Fix graphqlerror capture

### DIFF
--- a/src/main/java/org/opentripplanner/routing/graph/GraphIndex.java
+++ b/src/main/java/org/opentripplanner/routing/graph/GraphIndex.java
@@ -29,7 +29,6 @@ import com.google.common.collect.Sets;
 import graphql.ExceptionWhileDataFetching;
 import graphql.GraphQLError;
 import graphql.schema.GraphQLSchema;
-import graphql.schema.validation.ValidationError;
 
 import com.google.common.util.concurrent.ThreadFactoryBuilder;
 import com.vividsolutions.jts.geom.Coordinate;

--- a/src/main/java/org/opentripplanner/routing/graph/GraphIndex.java
+++ b/src/main/java/org/opentripplanner/routing/graph/GraphIndex.java
@@ -1062,13 +1062,13 @@ public class GraphIndex {
                 Sentry.getContext().addExtra("message", error.getMessage());
                 Sentry.getContext().addExtra("errorType", error.getErrorType());
                 if (error instanceof ExceptionWhileDataFetching) {
-                	Sentry.capture(((ExceptionWhileDataFetching) error).getException());	
+                    Sentry.capture(((ExceptionWhileDataFetching) error).getException());
                 } else {
-                	EventBuilder builder = new EventBuilder()
-            			.withMessage(error.toString())
-            			.withLevel(Event.Level.ERROR)
-            			.withLogger(LOG.getName());
-                	Sentry.capture(builder);
+                    EventBuilder builder = new EventBuilder()
+                        .withMessage(error.toString())
+                        .withLevel(Event.Level.ERROR)
+                        .withLogger(LOG.getName());
+                    Sentry.capture(builder);
                 }
             }
         }


### PR DESCRIPTION
The purpose of this pull request is to prevent the Sentry capture phase from crashing if the underlying error is not ExceptionWhileDataFetching but something else instead. These types of error usually come up when the incoming QraphQL query is not properly built or it does not match the schema.

Previously the server would return an HTTP 500 result with a message similar to: 
`"java.lang.ClassCastException: graphql.validation.ValidationError cannot be cast to graphql.ExceptionWhileDataFetching graphql.validation.ValidationError cannot be cast to graphql.ExceptionWhileDataFetching"`

Now the server still returns an HTTP 500 result but with a better error message:
```
{
    "errors": [
        {
            "validationErrorType": "FieldUndefined",
            "message": "Validation error of type FieldUndefined: Field asdf is undefined",
            "errorType": "ValidationError",
            "locations": [
                {
                    "line": 135,
                    "column": 62
                }
            ]
        }
    ]
}
```