### PR TITLE
Ignore 'batch' argument in GraphQL itinerary planning

### DIFF
--- a/src/main/java/org/opentripplanner/index/GraphQlPlanner.java
+++ b/src/main/java/org/opentripplanner/index/GraphQlPlanner.java
@@ -226,7 +226,7 @@ public class GraphQlPlanner {
             request.transferPenalty += 1800;
         }
 
-        callWith.argument("batch", (Boolean v) -> request.batch = v);
+        callWith.argument("batch", (Boolean v) -> /*request.batch = v*/ request.batch = false);
 
         if (optimize != null) {
             request.optimize = optimize;

--- a/src/main/java/org/opentripplanner/index/GraphQlPlanner.java
+++ b/src/main/java/org/opentripplanner/index/GraphQlPlanner.java
@@ -226,6 +226,7 @@ public class GraphQlPlanner {
             request.transferPenalty += 1800;
         }
 
+	//Set argument 'batch' to false, as it causes timeouts and is not useful for point-to-point itinerary planning
         callWith.argument("batch", (Boolean v) -> /*request.batch = v*/ request.batch = false);
 
         if (optimize != null) {


### PR DESCRIPTION
Using argument `batch: true` when planning an itinerary using GraphQL API causes a timeout after 5 seconds. 
Argument `batch` should not be used in the API anyway, as it's not useful for point-to-point itinerary planning.