### PR TITLE
Remove unnecessary prints

### DIFF
--- a/src/main/java/org/opentripplanner/routing/graph/Graph.java
+++ b/src/main/java/org/opentripplanner/routing/graph/Graph.java
@@ -814,9 +814,6 @@ public class Graph implements Serializable {
     }
 
     public void save(File file) throws IOException {
-        for (Vertex v : getVertices()) {
-            System.out.println("vertex: " + v.toString());
-        }
         LOG.info("Main graph size: |V|={} |E|={}", this.countVertices(), this.countEdges());
         LOG.info("Writing graph " + file.getAbsolutePath() + " ...");
         ObjectOutputStream out = new ObjectOutputStream(new BufferedOutputStream(
@@ -902,7 +899,6 @@ public class Graph implements Serializable {
                 toRemove.add(v);
         // avoid concurrent vertex map modification
         for (Vertex v : toRemove) {
-            System.out.println("remove: " + v.toString());
             this.remove(v);
             removed += 1;
             LOG.trace("removed edgeless vertex {}", v);


### PR DESCRIPTION
Remove unnecessary prints crashing data building process