### PR TITLE
Dt 2745

### DIFF
--- a/src/main/java/org/opentripplanner/graph_builder/module/osm/DefaultWayPropertySetSource.java
+++ b/src/main/java/org/opentripplanner/graph_builder/module/osm/DefaultWayPropertySetSource.java
@@ -299,7 +299,7 @@ public class DefaultWayPropertySetSource implements WayPropertySetSource {
         props.setProperties("highway=pedestrian;bicycle=designated",
                 StreetTraversalPermission.PEDESTRIAN_AND_BICYCLE, 0.75, 0.75);
         props.setProperties("highway=cycleway;bicycle=designated",
-                StreetTraversalPermission.PEDESTRIAN_AND_BICYCLE, 1.1, 1.1);
+                StreetTraversalPermission.PEDESTRIAN_AND_BICYCLE, 0.6, 0.6);
 
         /* sidewalk and crosswalk */
         props.setProperties("footway=sidewalk;highway=footway;bicycle=yes",

--- a/src/main/java/org/opentripplanner/graph_builder/module/osm/FinlandWayPropertySetSource.java
+++ b/src/main/java/org/opentripplanner/graph_builder/module/osm/FinlandWayPropertySetSource.java
@@ -54,6 +54,9 @@ public class FinlandWayPropertySetSource implements WayPropertySetSource {
         props.setCarSpeed("highway=primary", 22.22f); // 80kph "Kantatie"
         props.setCarSpeed("highway=primary_link", 15); // = 54kph
 
+        // Fixes problem with missing REDI park&ride tunnel connections
+        props.setProperties("highway=service;tunnel=yes", StreetTraversalPermission.ALL, 1.1, 1.1);
+
         // Remove Helsinki city center service tunnel network from graph
         props.setProperties("highway=service;tunnel=yes;access=destination", StreetTraversalPermission.NONE);
         props.setProperties("highway=service;access=destination", StreetTraversalPermission.ALL, 1.1, 1.1);


### PR DESCRIPTION
* Made OSM ways like https://www.openstreetmap.org/way/56760503#map=15/60.2127/24.9384 more preferred in cycling routing by decreasing weight for highway=cycleway, bicycle=designated combinations.
* Fixed problem in Finland way property configuration that left certain tunnels with highway=service, tunnel=yes unavailable for traversal (REDI park&ride was affected by this)