### PR TITLE
Output GTFS-RT statistics to log periodically

### DIFF
--- a/src/main/java/org/opentripplanner/updater/stoptime/PollingStoptimeUpdater.java
+++ b/src/main/java/org/opentripplanner/updater/stoptime/PollingStoptimeUpdater.java
@@ -129,7 +129,7 @@ public class PollingStoptimeUpdater extends PollingGraphUpdater {
 
                 // Set properties of realtime data snapshot source
                 if (logFrequency != null) {
-                    snapshotSource.analytics.setLogFrequency(logFrequency);
+                    snapshotSource.statistics.setLogFrequency(logFrequency);
                 }
                 if (maxSnapshotFrequency != null) {
                     snapshotSource.maxSnapshotFrequency = (maxSnapshotFrequency);

--- a/src/main/java/org/opentripplanner/updater/stoptime/PollingStoptimeUpdater.java
+++ b/src/main/java/org/opentripplanner/updater/stoptime/PollingStoptimeUpdater.java
@@ -129,7 +129,7 @@ public class PollingStoptimeUpdater extends PollingGraphUpdater {
 
                 // Set properties of realtime data snapshot source
                 if (logFrequency != null) {
-                    snapshotSource.logFrequency = (logFrequency);
+                    snapshotSource.analytics.setLogFrequency(logFrequency);
                 }
                 if (maxSnapshotFrequency != null) {
                     snapshotSource.maxSnapshotFrequency = (maxSnapshotFrequency);

--- a/src/main/java/org/opentripplanner/updater/stoptime/TimetableSnapshotSource.java
+++ b/src/main/java/org/opentripplanner/updater/stoptime/TimetableSnapshotSource.java
@@ -52,9 +52,7 @@ public class TimetableSnapshotSource {
      */
     private static final long MAX_ARRIVAL_DEPARTURE_TIME = 48 * 60 * 60;
 
-    public int logFrequency = 2000;
-
-    private int appliedBlockCount = 0;
+    public GtfsRealtimeStatistics analytics = new GtfsRealtimeStatistics();
 
     /**
      * If a timetable snapshot is requested less than this number of milliseconds after the previous
@@ -195,6 +193,7 @@ public class TimetableSnapshotSource {
 
                 if (!tripUpdate.hasTrip()) {
                     LOG.warn("Missing TripDescriptor in gtfs-rt trip update: \n{}", tripUpdate);
+                    analytics.increaseRejected();
                     continue;
                 }
 
@@ -206,6 +205,7 @@ public class TimetableSnapshotSource {
                         serviceDate = ServiceDate.parseString(tripDescriptor.getStartDate());
                     } catch (final ParseException e) {
                         LOG.warn("Failed to parse start date in gtfs-rt trip update: \n{}", tripUpdate);
+                        analytics.increaseRejected();
                         continue;
                     }
                 } else {
@@ -241,17 +241,16 @@ public class TimetableSnapshotSource {
                 }
 
                 if (applied) {
-                    appliedBlockCount++;
+                    analytics.increaseApplied();
                 } else {
                     LOG.info("Failed to apply TripUpdate.");
                     LOG.trace(" Contents: {}", tripUpdate);
+                    analytics.increaseRejected();
                 }
 
-                if (appliedBlockCount > 0 && appliedBlockCount % logFrequency == 0) {
-                    LOG.info("Applied {} trip updates.", appliedBlockCount);
-                }
             }
             LOG.debug("end of update message");
+            analytics.printAndClear();
 
             // Make a snapshot after each message in anticipation of incoming requests
             // Purge data if necessary (and force new snapshot if anything was purged)
@@ -972,4 +971,37 @@ public class TimetableSnapshotSource {
         return stop;
     }
 
+    /**
+     * Simple logger to provide some statistics about processed GTFS-RT messages.
+     */
+    static class GtfsRealtimeStatistics {
+        private static final Logger LOG = LoggerFactory.getLogger(GtfsRealtimeStatistics.class);
+
+        private int logFrequency = 2000;
+        private int appliedBlockCount = 0;
+        private int rejectedBlockCount = 0;
+
+        public void setLogFrequency(int frequency) {
+            logFrequency = frequency;
+        }
+
+        public void increaseApplied() {
+            appliedBlockCount++;
+        }
+
+        public void increaseRejected() {
+            rejectedBlockCount++;
+        }
+
+        public void printAndClear() {
+            int sum = appliedBlockCount + rejectedBlockCount;
+            if (sum >= logFrequency) {
+                float percentage = 100.0f * (float)appliedBlockCount / (float)sum;
+                LOG.info("Gtfs-Rt statistics: applied {} messages, rejected {} messages, success rate {} %",
+                        appliedBlockCount, rejectedBlockCount, percentage);
+                appliedBlockCount = 0;
+                rejectedBlockCount = 0;
+            }
+        }
+    }
 }

--- a/src/main/java/org/opentripplanner/updater/stoptime/TimetableSnapshotSource.java
+++ b/src/main/java/org/opentripplanner/updater/stoptime/TimetableSnapshotSource.java
@@ -52,7 +52,7 @@ public class TimetableSnapshotSource {
      */
     private static final long MAX_ARRIVAL_DEPARTURE_TIME = 48 * 60 * 60;
 
-    public GtfsRealtimeStatistics analytics = new GtfsRealtimeStatistics();
+    public final GtfsRealtimeStatistics statistics = new GtfsRealtimeStatistics();
 
     /**
      * If a timetable snapshot is requested less than this number of milliseconds after the previous
@@ -193,7 +193,7 @@ public class TimetableSnapshotSource {
 
                 if (!tripUpdate.hasTrip()) {
                     LOG.warn("Missing TripDescriptor in gtfs-rt trip update: \n{}", tripUpdate);
-                    analytics.increaseRejected();
+                    statistics.increaseRejected();
                     continue;
                 }
 
@@ -205,7 +205,7 @@ public class TimetableSnapshotSource {
                         serviceDate = ServiceDate.parseString(tripDescriptor.getStartDate());
                     } catch (final ParseException e) {
                         LOG.warn("Failed to parse start date in gtfs-rt trip update: \n{}", tripUpdate);
-                        analytics.increaseRejected();
+                        statistics.increaseRejected();
                         continue;
                     }
                 } else {
@@ -241,16 +241,16 @@ public class TimetableSnapshotSource {
                 }
 
                 if (applied) {
-                    analytics.increaseApplied();
+                    statistics.increaseApplied();
                 } else {
                     LOG.info("Failed to apply TripUpdate.");
                     LOG.trace(" Contents: {}", tripUpdate);
-                    analytics.increaseRejected();
+                    statistics.increaseRejected();
                 }
 
             }
             LOG.debug("end of update message");
-            analytics.printAndClear();
+            statistics.printAndClear();
 
             // Make a snapshot after each message in anticipation of incoming requests
             // Purge data if necessary (and force new snapshot if anything was purged)

--- a/src/main/resources/logback.xml
+++ b/src/main/resources/logback.xml
@@ -52,13 +52,14 @@
   <logger name="com.amazonaws" level="info"/>
   <logger name="org.apache.http" level="info" />
   <logger name="com.conveyal" level="info"/>
-  <!-- for now disable realtime logging -->
+  <!-- for now disable realtime logging, leave only statistics -->
   <logger name="org.opentripplanner.updater.bike_rental.SmooveBikeRentalDataSource" level="warn" />
   <logger name="org.opentripplanner.updater.bike_rental.BikeRentalUpdater" level="warn" />
   <logger name="org.opentripplanner.updater.stoptime.TimetableSnapshotSource" level="error" />
+  <logger name="org.opentripplanner.updater.stoptime.TimetableSnapshotSource$GtfsRealtimeStatistics" level="info" />
   <logger name="org.opentripplanner.routing.edgetype.Timetable" level="off" />
   <logger name="org.opentripplanner.routing.trippattern.TripTimes" level="off" />
-  <!-- /for now disable realtime logging -->   
+  <!-- /for now disable realtime logging, leave only statistics -->
   <logger name="org.opentripplanner.graph_builder.module.DirectTransferGenerator" level="info" />
   <logger name="org.opentripplanner" level="info" />
   <logger name="org.opentripplanner.analyst" level="info" />


### PR DESCRIPTION
Prints out better statistics about GTFS-RT TripUpdate handling.

To be completed by pull request submitter:

- [ ] **issue**: Link to or create an [issue](https://github.com/opentripplanner/OpenTripPlanner/issues) that describes the relevant feature or bug. Add [GitHub keywords](https://help.github.com/articles/closing-issues-using-keywords/) to this PR's description (e.g., `closes #45`).
- [ ] **roadmap**: Check the [roadmap](https://github.com/orgs/opentripplanner/projects/1) for this feature or bug. If it is not already on the roadmap, PLC will discuss as part of the review process.
- [ ] **tests**: Have you added relevant test coverage? Are all the tests passing on [the continuous integration service (Travis CI)](https://github.com/opentripplanner/OpenTripPlanner/blob/master/docs/Developers-Guide.md#continuous-integration)?
- [X] **formatting**: Have you followed the [suggested code style](https://github.com/opentripplanner/OpenTripPlanner/blob/master/docs/Developers-Guide.md#code-style)? 

To be completed by @opentripplanner/plc:

- [ ] reviews and approvals by 2 members, ideally from different organizations
- [ ] **before merging**: add a bullet point to the [changelog file](https://github.com/opentripplanner/OpenTripPlanner/blob/master/docs/Changelog.md) with description and link to the linked issue
- [ ] **after merging**: update the relevant card on the [roadmap](https://github.com/orgs/opentripplanner/projects/1)