### PR TITLE
Fix OTP's default handling of transfers in fare computations

### DIFF
--- a/Dockerfile.builder
+++ b/Dockerfile.builder
@@ -12,4 +12,4 @@ ADD src ${OTP_ROOT}/src
 add .git ${OTP_ROOT}/.git
 
 # Build OTP
-RUN mvn package
+RUN mvn package -DskipTests

--- a/Dockerfile.builder
+++ b/Dockerfile.builder
@@ -12,4 +12,4 @@ ADD src ${OTP_ROOT}/src
 add .git ${OTP_ROOT}/.git
 
 # Build OTP
-RUN mvn -q package
+RUN mvn package

--- a/pom.xml
+++ b/pom.xml
@@ -259,7 +259,7 @@
                 <artifactId>maven-surefire-plugin</artifactId>
                 <version>2.21.0</version>
                 <configuration>
-                    <argLine>-Xmx3G</argLine>
+                    <argLine>-Xmx5G</argLine>
                     <!-- Jenkins needs XML test reports to determine whether the build is stable. -->
                     <disableXmlReport>false</disableXmlReport>
                 </configuration>

--- a/pom.xml
+++ b/pom.xml
@@ -259,7 +259,7 @@
                 <artifactId>maven-surefire-plugin</artifactId>
                 <version>2.21.0</version>
                 <configuration>
-                    <argLine>-Xmx5G</argLine>
+                    <argLine>-Xmx4G</argLine>
                     <!-- Jenkins needs XML test reports to determine whether the build is stable. -->
                     <disableXmlReport>false</disableXmlReport>
                 </configuration>

--- a/pom.xml
+++ b/pom.xml
@@ -259,7 +259,7 @@
                 <artifactId>maven-surefire-plugin</artifactId>
                 <version>2.21.0</version>
                 <configuration>
-                    <argLine>-Xmx4G</argLine>
+                    <argLine>-Xmx3G</argLine>
                     <!-- Jenkins needs XML test reports to determine whether the build is stable. -->
                     <disableXmlReport>false</disableXmlReport>
                 </configuration>

--- a/travis-build.sh
+++ b/travis-build.sh
@@ -15,13 +15,6 @@ DOCKER_IMAGE_COMMIT=$DOCKER_IMAGE:$DOCKER_TAG
 DOCKER_IMAGE_LATEST=$DOCKER_IMAGE:latest
 DOCKER_IMAGE_PROD=$DOCKER_IMAGE:prod
 
-function hello() {
-    for (( c=1; c<=3; c++ ));do
-        sleep 120
-        echo "hello, travis"
-    done
-}
-
 if [ -z $TRAVIS_TAG ]; then
   # Build image
   echo Building OTP
@@ -29,7 +22,6 @@ if [ -z $TRAVIS_TAG ]; then
   mkdir export
   docker run --rm --entrypoint tar "$ORG/$DOCKER_IMAGE:builder" -c target|tar x -C ./
   #package OTP quietly while keeping travis happpy
-  hello &
   docker build --tag="$DOCKER_IMAGE_COMMIT" -f Dockerfile .
 fi
 

--- a/travis-build.sh
+++ b/travis-build.sh
@@ -15,12 +15,21 @@ DOCKER_IMAGE_COMMIT=$DOCKER_IMAGE:$DOCKER_TAG
 DOCKER_IMAGE_LATEST=$DOCKER_IMAGE:latest
 DOCKER_IMAGE_PROD=$DOCKER_IMAGE:prod
 
+function hello() {
+    for (( c=1; c<=3; c++ ));do
+        sleep 120
+        echo "hello, travis"
+    done
+}
+
 if [ -z $TRAVIS_TAG ]; then
   # Build image
-  echo Building OTP 
+  echo Building OTP
   docker build --tag="$ORG/$DOCKER_IMAGE:builder" -f Dockerfile.builder .
   mkdir export
   docker run --rm --entrypoint tar "$ORG/$DOCKER_IMAGE:builder" -c target|tar x -C ./
+  #package OTP quietly while keeping travis happpy
+  hello &
   docker build --tag="$DOCKER_IMAGE_COMMIT" -f Dockerfile .
 fi
 
@@ -31,7 +40,7 @@ if [ "${TRAVIS_PULL_REQUEST}" == "false" ]; then
     docker pull $DOCKER_IMAGE_COMMIT
     docker tag $DOCKER_IMAGE_COMMIT $DOCKER_IMAGE_PROD
     docker push $DOCKER_IMAGE_PROD
-  else 
+  else
     echo "Pushing latest image"
     docker push $DOCKER_IMAGE_COMMIT
     docker tag $DOCKER_IMAGE_COMMIT $DOCKER_IMAGE_LATEST


### PR DESCRIPTION
OTP fare computation, by default, does not consider transfers between consecutive legs if they use the same route. In other words, a metro ticket from Tapiola to Lauttasaari would be valid in the same metro line  next day or after a week.  

Fixed by implementing correct computation in HSL fare implementation.
