### PR TITLE
Use mesos env variable for azure dns workaround

### DIFF
--- a/run.sh
+++ b/run.sh
@@ -83,8 +83,8 @@ function process {
 
 #workaround for azure DNS issue
 
-if [ "$EUID" -eq 0 ]
-  then echo "search marathon.l4lb.thisdcos.directory" >> /etc/resolv.conf
+if [ -n "$MESOS_CONTAINER_NAME"  ]; then 
+  echo "search marathon.l4lb.thisdcos.directory" >> /etc/resolv.conf
 fi
 
 VERSION=$(version)


### PR DESCRIPTION
The current workaround for the azure/mesos dns issue, introduced in 87069171aeca2cb0f6012a308172d0782aef38c5 / #114, breaks the dns resolution of this container in other systems like kubernetes.
`EUID` happens to be 0 there too, but the search domain cannot be used.

This PR changes the way mesos is detected to the `MESOS_CONTAINER_NAME` env, as it is used in other containers like digitransit-proxy: 
https://github.com/HSLdevcom/digitransit-proxy/blob/83c64decb1196d0329d65d369ff35bf99bcf720c/run.sh#L5