### PR TITLE
Fix bike rental station vertex updating in graph 

### DIFF
--- a/src/main/java/org/opentripplanner/routing/vertextype/BikeRentalStationVertex.java
+++ b/src/main/java/org/opentripplanner/routing/vertextype/BikeRentalStationVertex.java
@@ -76,4 +76,10 @@ public class BikeRentalStationVertex extends Vertex {
     public BikeRentalStation getStation() {
         return station;
     }
+
+    public void setStation(BikeRentalStation station) {
+        this.station = station;
+        this.bikesAvailable = station.bikesAvailable;
+        this.spacesAvailable = station.spacesAvailable;
+    }
 }

--- a/src/main/java/org/opentripplanner/updater/bike_rental/BikeRentalUpdater.java
+++ b/src/main/java/org/opentripplanner/updater/bike_rental/BikeRentalUpdater.java
@@ -158,7 +158,7 @@ public class BikeRentalUpdater extends PollingGraphUpdater {
             this.stations = stations;
         }
 
-		@Override
+        @Override
         public void run(Graph graph) {
             // Apply stations to graph
             Set<BikeRentalStation> stationSet = new HashSet<>();
@@ -183,8 +183,7 @@ public class BikeRentalUpdater extends PollingGraphUpdater {
                     if (station.allowDropoff)
                         new RentABikeOffEdge(vertex, vertex, station.networks);
                 } else {
-                    vertex.setBikesAvailable(station.bikesAvailable);
-                    vertex.setSpacesAvailable(station.spacesAvailable);
+                    vertex.setStation(station);
                 }
             }
             /* remove existing stations that were not present in the update */


### PR DESCRIPTION
Accessing bike rental stations via graph was broken (always used outdated version of station state).