### PR TITLE
Reverts changes from #289 and #281 that caused unwanted triptimes can…

### DIFF
--- a/src/main/java/org/opentripplanner/api/resource/GraphPathToTripPlanConverter.java
+++ b/src/main/java/org/opentripplanner/api/resource/GraphPathToTripPlanConverter.java
@@ -748,15 +748,7 @@ public abstract class GraphPathToTripPlanConverter {
             leg.arrivalDelay = tripTimes.getArrivalDelay(leg.to.stopIndex);
 
 
-            if (tripTimes.isCanceled()) {
-                leg.realTimeState = RealTimeState.CANCELED;
-            } else if (leg.from.stopIndex != null && tripTimes.isCanceledDeparture(leg.from.stopIndex)) {
-                leg.realTimeState = RealTimeState.CANCELED;
-            } else if (leg.to.stopIndex != null && tripTimes.isCanceledArrival(leg.to.stopIndex)) {
-                leg.realTimeState = RealTimeState.CANCELED;
-            } else {
-                leg.realTimeState = tripTimes.getRealTimeState();
-            }
+            leg.realTimeState = tripTimes.getRealTimeState();
         }
     }
 

--- a/src/main/java/org/opentripplanner/index/model/TripTimeShort.java
+++ b/src/main/java/org/opentripplanner/index/model/TripTimeShort.java
@@ -50,7 +50,7 @@ public class TripTimeShort {
         timepoint          = tt.isTimepoint(i);
         realtime           = !tt.isScheduled();
         tripId             = tt.trip.getId();
-        realtimeState      = tt.isTimeCanceled(i) ? RealTimeState.CANCELED : tt.getRealTimeState();
+        realtimeState      = tt.getRealTimeState();
         blockId            = tt.trip.getBlockId();
         headsign           = tt.getHeadsign(i);
     }

--- a/src/main/java/org/opentripplanner/routing/graph/GraphIndex.java
+++ b/src/main/java/org/opentripplanner/routing/graph/GraphIndex.java
@@ -822,7 +822,7 @@ public class GraphIndex {
                         if (!sd.serviceRunning(triptimes.serviceCode))
                             continue;
                         int stopDepartureTime = triptimes.getDepartureTime(stopIndex);
-                        if (!(omitCanceled && triptimes.isCanceledDeparture(stopIndex)) && stopDepartureTime >= starttimeSecondsSinceMidnight && stopDepartureTime < starttimeSecondsSinceMidnight + timeRange) {
+                        if (!(omitCanceled && stopDepartureTime != -1) && stopDepartureTime >= starttimeSecondsSinceMidnight && stopDepartureTime < starttimeSecondsSinceMidnight + timeRange) {
                             ret.insertWithOverflow(new TripTimeShort(triptimes, stopIndex, currStop, sd));
                             }
                         }

--- a/src/main/java/org/opentripplanner/routing/graph/GraphIndex.java
+++ b/src/main/java/org/opentripplanner/routing/graph/GraphIndex.java
@@ -822,7 +822,7 @@ public class GraphIndex {
                         if (!sd.serviceRunning(triptimes.serviceCode))
                             continue;
                         int stopDepartureTime = triptimes.getDepartureTime(stopIndex);
-                        if (!(omitCanceled && stopDepartureTime != -1) && stopDepartureTime >= starttimeSecondsSinceMidnight && stopDepartureTime < starttimeSecondsSinceMidnight + timeRange) {
+                        if (!(omitCanceled && stopDepartureTime == -1) && stopDepartureTime >= starttimeSecondsSinceMidnight && stopDepartureTime < starttimeSecondsSinceMidnight + timeRange) {
                             ret.insertWithOverflow(new TripTimeShort(triptimes, stopIndex, currStop, sd));
                             }
                         }

--- a/src/main/java/org/opentripplanner/routing/trippattern/TripTimes.java
+++ b/src/main/java/org/opentripplanner/routing/trippattern/TripTimes.java
@@ -84,10 +84,6 @@ public class TripTimes implements Serializable, Comparable<TripTimes>, Cloneable
      */
     int[] departureTimes;
 
-    BitSet canceledArrivalTimes;
-
-    BitSet canceledDepartureTimes;
-
     /**
      * These are the GTFS stop sequence numbers, which show the order in which the vehicle visits
      * the stops. Despite the face that the StopPattern or TripPattern enclosing this TripTimes
@@ -118,9 +114,6 @@ public class TripTimes implements Serializable, Comparable<TripTimes>, Cloneable
         final int[] arrivals   = new int[nStops];
         final int[] sequences  = new int[nStops];
         final BitSet timepoints = new BitSet(nStops);
-
-        canceledArrivalTimes = new BitSet(nStops);
-        canceledDepartureTimes = new BitSet(nStops);
 
         // Times are always shifted to zero. This is essential for frequencies and deduplication.
         timeShift = stopTimes.get(0).getArrivalTime();
@@ -156,9 +149,6 @@ public class TripTimes implements Serializable, Comparable<TripTimes>, Cloneable
         this.scheduledArrivalTimes = object.scheduledArrivalTimes;
         this.stopSequences = object.stopSequences;
         this.timepoints = object.timepoints;
-
-        canceledArrivalTimes = new BitSet(object.scheduledDepartureTimes.length);
-        canceledDepartureTimes = new BitSet(object.scheduledDepartureTimes.length);
     }
 
     /**
@@ -261,7 +251,7 @@ public class TripTimes implements Serializable, Comparable<TripTimes>, Cloneable
      *         information is actually available in this TripTimes.
      */
     public boolean isScheduled() {
-        return departureTimes == null && arrivalTimes == null && canceledArrivalTimes.isEmpty() && canceledDepartureTimes.isEmpty();
+        return departureTimes == null && arrivalTimes == null;
     }
 
     /**
@@ -342,14 +332,9 @@ public class TripTimes implements Serializable, Comparable<TripTimes>, Cloneable
 
     /** Cancel this entire trip */
     public void cancel() {
-        /*
         arrivalTimes = new int[getNumStops()];
         Arrays.fill(arrivalTimes, UNAVAILABLE);
         departureTimes = arrivalTimes;
-        */
-
-        canceledArrivalTimes.set(0, canceledArrivalTimes.size());
-        canceledDepartureTimes.set(0, canceledDepartureTimes.size());
 
         // Update the real-time state
         realTimeState = RealTimeState.CANCELED;
@@ -421,7 +406,7 @@ public class TripTimes implements Serializable, Comparable<TripTimes>, Cloneable
     * without updates for now (frequency trips don't have updates).
     */
     public TripTimes timeShift (final int stop, final int time, final boolean depart) {
-        if (arrivalTimes != null || departureTimes != null || !canceledDepartureTimes.isEmpty() || !canceledArrivalTimes.isEmpty()) return null;
+        if (arrivalTimes != null || departureTimes != null) return null;
         final TripTimes shifted = this.clone();
         // Adjust 0-based times to match desired stoptime.
         final int shift = time - (depart ? getDepartureTime(stop) : getArrivalTime(stop));
@@ -439,14 +424,6 @@ public class TripTimes implements Serializable, Comparable<TripTimes>, Cloneable
         return timepoints.get(stopIndex);
     }
 
-    public boolean isCanceledArrival (final int stopIndex) {
-       return canceledArrivalTimes.get(stopIndex);
-    }
-
-    public boolean isCanceledDeparture (final int stopIndex) {
-        return canceledDepartureTimes.get(stopIndex);
-    }
-
     /**
      * Hash the scheduled arrival/departure times. Used in creating stable IDs for trips across GTFS feed versions.
      * Use hops rather than stops because:
@@ -460,24 +437,5 @@ public class TripTimes implements Serializable, Comparable<TripTimes>, Cloneable
             hasher.putInt(getScheduledArrivalTime(hop + 1));
         }
         return hasher.hash();
-    }
-
-    public void cancelArrivalTime(int i) {
-        canceledArrivalTimes.set(i);
-    }
-    public void unCancelArrivalTime(int i) {
-        canceledArrivalTimes.clear(i);
-    }
-
-    public void cancelDepartureTime(int i) {
-        canceledDepartureTimes.set(i);
-    }
-
-    public void unCancelDepartureTime(int i) {
-        canceledDepartureTimes.clear(i);
-    }
-
-    public boolean isTimeCanceled(int i) {
-        return isCanceledArrival(i) || isCanceledDeparture(i) || isCanceled();
     }
 }

--- a/src/test/java/org/opentripplanner/routing/edgetype/TimetableTest.java
+++ b/src/test/java/org/opentripplanner/routing/edgetype/TimetableTest.java
@@ -196,10 +196,8 @@ public class TimetableTest {
 
         TripTimes tripTimes = timetable.getTripTimes(trip_1_1_index);
         for (int i = 0; i < tripTimes.getNumStops(); i++) {
-            assertEquals(tripTimes.getScheduledDepartureTime(i), tripTimes.getDepartureTime(i));
-            assertEquals(tripTimes.getScheduledArrivalTime(i), tripTimes.getArrivalTime(i));
-            assertTrue(tripTimes.isCanceledDeparture(i));
-            assertTrue(tripTimes.isCanceledArrival(i));
+                assertEquals(TripTimes.UNAVAILABLE, tripTimes.getDepartureTime(i));
+                assertEquals(TripTimes.UNAVAILABLE, tripTimes.getArrivalTime(i));
         }
 
         //---

--- a/src/test/java/org/opentripplanner/routing/trippattern/TripTimesTest.java
+++ b/src/test/java/org/opentripplanner/routing/trippattern/TripTimesTest.java
@@ -145,8 +145,8 @@ public class TripTimesTest {
                     updatedTripTimesA.getScheduledDepartureTime(i));
             assertEquals(originalTripTimes.getArrivalTime(i),
                     updatedTripTimesA.getScheduledArrivalTime(i));
-            assertTrue(updatedTripTimesA.isCanceledDeparture(i));
-            assertTrue(updatedTripTimesA.isCanceledArrival(i));
+            assertEquals(TripTimes.UNAVAILABLE, updatedTripTimesA.getDepartureTime(i));
+            assertEquals(TripTimes.UNAVAILABLE, updatedTripTimesA.getArrivalTime(i));
         }
     }
 

--- a/src/test/java/org/opentripplanner/updater/stoptime/TimetableSnapshotSourceTest.java
+++ b/src/test/java/org/opentripplanner/updater/stoptime/TimetableSnapshotSourceTest.java
@@ -156,8 +156,8 @@ public class TimetableSnapshotSourceTest {
 
         final TripTimes tripTimes = forToday.getTripTimes(tripIndex);
         for (int i = 0; i < tripTimes.getNumStops(); i++) {
-            assertTrue(tripTimes.isCanceledDeparture(i));
-            assertTrue(tripTimes.isCanceledArrival(i));
+            assertEquals(TripTimes.UNAVAILABLE, tripTimes.getDepartureTime(i));
+            assertEquals(TripTimes.UNAVAILABLE, tripTimes.getArrivalTime(i));
         }
         assertEquals(RealTimeState.CANCELED, tripTimes.getRealTimeState());
     }


### PR DESCRIPTION
The way trip cancellations were done caused missing future trip times to be cancelled (for example. arrival time is missing from a stop before it should have happened). This reverts some changes from https://github.com/HSLdevcom/OpenTripPlanner/pull/281 and https://github.com/HSLdevcom/OpenTripPlanner/pull/289

To be completed by pull request submitter:

- [ ] **issue**: Link to or create an [issue](https://github.com/opentripplanner/OpenTripPlanner/issues) that describes the relevant feature or bug. Add [GitHub keywords](https://help.github.com/articles/closing-issues-using-keywords/) to this PR's description (e.g., `closes #45`).
- [ ] **roadmap**: Check the [roadmap](https://github.com/orgs/opentripplanner/projects/1) for this feature or bug. If it is not already on the roadmap, PLC will discuss as part of the review process.
- [ ] **tests**: Have you added relevant test coverage? Are all the tests passing on [the continuous integration service (Travis CI)](https://github.com/opentripplanner/OpenTripPlanner/blob/master/docs/Developers-Guide.md#continuous-integration)?
- [ ] **formatting**: Have you followed the [suggested code style](https://github.com/opentripplanner/OpenTripPlanner/blob/master/docs/Developers-Guide.md#code-style)? 

To be completed by @opentripplanner/plc:

- [ ] reviews and approvals by 2 members, ideally from different organizations
- [ ] **before merging**: add a bullet point to the [changelog file](https://github.com/opentripplanner/OpenTripPlanner/blob/master/docs/Changelog.md) with description and link to the linked issue
- [ ] **after merging**: update the relevant card on the [roadmap](https://github.com/orgs/opentripplanner/projects/1)