### PR TITLE
Realtime fixes

### DIFF
--- a/src/main/java/org/opentripplanner/index/IndexAPI.java
+++ b/src/main/java/org/opentripplanner/index/IndexAPI.java
@@ -286,7 +286,7 @@ public class IndexAPI {
             return Response.status(Status.BAD_REQUEST).entity(MSG_400).build();
         }
 
-        List<StopTimesInPattern> ret = index.getStopTimesForStop(stop, sd, omitNonPickups);
+        List<StopTimesInPattern> ret = index.getStopTimesForStop(stop, sd, omitNonPickups, false);
         return Response.status(Status.OK).entity(ret).build();
     }
 

--- a/src/main/java/org/opentripplanner/index/IndexGraphQLSchema.java
+++ b/src/main/java/org/opentripplanner/index/IndexGraphQLSchema.java
@@ -1440,7 +1440,7 @@ public class IndexGraphQLSchema {
                                 .name("omitCanceled")
                                 .description("If false, returns also canceled trips")
                                 .type(Scalars.GraphQLBoolean)
-                                .defaultValue(true)
+                                .defaultValue(false)
                                 .build())
                         .dataFetcher(environment -> {
                             ServiceDate date;
@@ -1451,15 +1451,16 @@ public class IndexGraphQLSchema {
                             }
                             Stop stop = environment.getSource();
                             boolean omitNonPickups = environment.getArgument("omitNonPickups");
+                            boolean omitCanceled = environment.getArgument("omitCanceled");
                             if (stop.getLocationType() == 1) {
                                 // Merge all stops if this is a station
                                 return index.stopsForParentStation
                                         .get(stop.getId())
                                         .stream()
-                                        .flatMap(singleStop -> index.getStopTimesForStop(singleStop, date, omitNonPickups).stream())
+                                        .flatMap(singleStop -> index.getStopTimesForStop(singleStop, date, omitNonPickups, omitCanceled).stream())
                                         .collect(Collectors.toList());
                             }
-                            return index.getStopTimesForStop(stop, date, omitNonPickups);
+                            return index.getStopTimesForStop(stop, date, omitNonPickups, omitCanceled);
                         })
                         .build())
                 .field(GraphQLFieldDefinition.newFieldDefinition()

--- a/src/main/java/org/opentripplanner/routing/edgetype/Timetable.java
+++ b/src/main/java/org/opentripplanner/routing/edgetype/Timetable.java
@@ -433,11 +433,7 @@ public class Timetable implements Serializable {
                     StopTimeUpdate.ScheduleRelationship scheduleRelationship =
                             update.hasScheduleRelationship() ? update.getScheduleRelationship()
                             : StopTimeUpdate.ScheduleRelationship.SCHEDULED;
-                    if (scheduleRelationship == StopTimeUpdate.ScheduleRelationship.SKIPPED) {
-                        LOG.warn("Partially canceled trips are unsupported by this method." +
-                                " Skipping TripUpdate.");
-                        return null;
-                    } else if (scheduleRelationship ==
+                    if (scheduleRelationship ==
                             StopTimeUpdate.ScheduleRelationship.NO_DATA) {
                         newTimes.updateArrivalDelay(i, 0);
                         newTimes.updateDepartureDelay(i, 0);
@@ -523,6 +519,11 @@ public class Timetable implements Serializable {
                                 }
                             }
                         }
+                    }
+
+                    if (scheduleRelationship == StopTimeUpdate.ScheduleRelationship.SKIPPED) {
+                        newTimes.cancelArrivalTime(i);
+                        newTimes.cancelDepartureTime(i);
                     }
 
                     if (updates.hasNext()) {

--- a/src/main/java/org/opentripplanner/routing/graph/GraphIndex.java
+++ b/src/main/java/org/opentripplanner/routing/graph/GraphIndex.java
@@ -861,9 +861,10 @@ public class GraphIndex {
      *
      * @param stop Stop object to perform the search for
      * @param serviceDate Return all departures for the specified date
+     * @param omitCanceled
      * @return
      */
-    public List<StopTimesInPattern> getStopTimesForStop(Stop stop, ServiceDate serviceDate, boolean omitNonPickups) {
+    public List<StopTimesInPattern> getStopTimesForStop(Stop stop, ServiceDate serviceDate, boolean omitNonPickups, boolean omitCanceled) {
         List<StopTimesInPattern> ret = new ArrayList<>();
         TimetableSnapshot snapshot = null;
         if (graph.timetableSnapshotSource != null) {
@@ -885,6 +886,7 @@ public class GraphIndex {
                     if(omitNonPickups && pattern.stopPattern.pickups[sidx] == pattern.stopPattern.PICKDROP_NONE) continue;
                     for (TripTimes t : tt.tripTimes) {
                         if (!sd.serviceRunning(t.serviceCode)) continue;
+                        if (omitCanceled && t.isTimeCanceled(sidx)) continue;
                         stopTimes.times.add(new TripTimeShort(t, sidx, stop, sd));
                     }
                 }

--- a/src/main/java/org/opentripplanner/routing/trippattern/TripTimes.java
+++ b/src/main/java/org/opentripplanner/routing/trippattern/TripTimes.java
@@ -480,4 +480,18 @@ public class TripTimes implements Serializable, Comparable<TripTimes>, Cloneable
     public boolean isTimeCanceled(int i) {
         return isCanceledArrival(i) || isCanceledDeparture(i) || isCanceled();
     }
+
+    public void propagateDelayBackwards(Integer firstDelay) {
+        int numStops = this.getNumStops();
+
+        for (int i = 0; i < numStops; i++) {
+            if (this.getArrivalDelay(i) != 0) {
+                break;
+            }
+
+            this.updateArrivalDelay(i, firstDelay);
+            this.updateDepartureDelay(i, firstDelay);
+        }
+    }
+
 }

--- a/src/test/java/org/opentripplanner/routing/edgetype/TimetableTest.java
+++ b/src/test/java/org/opentripplanner/routing/edgetype/TimetableTest.java
@@ -282,7 +282,8 @@ public class TimetableTest {
         assertNotNull(updatedTripTimes);
         timetable.setTripTimes(trip_1_1_index, updatedTripTimes);
 
-        // update trip arrival time at first stop and make departure time incoherent at second stop
+        // update trip arrival time at first stop and make departure time incoherent at second stop,
+        // changes should be propagated backwards
         tripDescriptorBuilder = TripDescriptor.newBuilder();
         tripDescriptorBuilder.setTripId("1.1");
         tripDescriptorBuilder.setScheduleRelationship(
@@ -303,6 +304,6 @@ public class TimetableTest {
         stopTimeEventBuilder.setDelay(-1);
         tripUpdate = tripUpdateBuilder.build();
         updatedTripTimes = timetable.createUpdatedTripTimes(tripUpdate, timeZone, serviceDate);
-        assertNull(updatedTripTimes);
+        assertNotNull(updatedTripTimes);
     }
 }


### PR DESCRIPTION
Fixes several issues with GTFS-RT tripupdate and realtime handling:
- omitCancelled-parameter was not used in GraphIndex.getStopTimesForStop and certain GraphQL API queries
- Invalid GTFS-RT TripUpdate stop patterns and StopTimeUpdates caused parts of trip being cancelled
- Early running trip in TripUpdate containing invalid / incomplete stop pattern and StopTimeUpdates caused the TripUpdate to be rejected
- Partial cancellations (SKIPPED StopTimeUpdates) were handled in a way that caused trips to appear cancelled as temporary trips created don't in GraphIndex. Implemented SKIPPED handling to `createUpdatedTripTimes` and `Timetable` to allow partially cancelled scheduled trips in strictly clear-cut cases where TripUpdate stop pattern matches existing trip pattern exactly