### PR TITLE
Do not use modified trip processing it trip matches but stops doesn't

### DIFF
--- a/src/main/java/org/opentripplanner/updater/stoptime/TimetableSnapshotSource.java
+++ b/src/main/java/org/opentripplanner/updater/stoptime/TimetableSnapshotSource.java
@@ -877,6 +877,9 @@ public class TimetableSnapshotSource {
                 LOG.warn("MODIFIED trip {} matches existing SCHEDULED trip. Treating as such.", trip.getId().getId());
                 return handleScheduledTrip(tripUpdate, feedId, serviceDate);
             }
+            // Do not modify scheduled trips as it causes canceled trip to appear in indexes and replacement trip not added to indexes
+            LOG.error("MODIFIED trip {} matches existing SCHEDULED trip. Stop patterns do not match SKIPPING", trip.getId().getId());
+            return false;
         }
 
         // Cancel scheduled trip

--- a/src/test/java/org/opentripplanner/updater/stoptime/TimetableSnapshotSourceTest.java
+++ b/src/test/java/org/opentripplanner/updater/stoptime/TimetableSnapshotSourceTest.java
@@ -1,11 +1,6 @@
 package org.opentripplanner.updater.stoptime;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNotSame;
-import static org.junit.Assert.assertSame;
-import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.*;
 import static org.opentripplanner.calendar.impl.CalendarServiceDataFactoryImpl.createCalendarServiceData;
 
 import java.io.File;
@@ -429,7 +424,12 @@ public class TimetableSnapshotSourceTest {
 
         // THEN
         final TimetableSnapshot snapshot = updater.getTimetableSnapshot();
+        assertNull(snapshot);
 
+        // Current temporary changes to tripUpdate handling doesn't allow modifying trips
+        // if stop sequence does not exactly match existing scheduled trip
+        // TODO: Teemu Peltonen 27.6.2019 Fix this test after fixing handling MODIFIED tripupdates   
+        /*
         // Original trip pattern
         {
             final FeedScopedId tripId = new FeedScopedId(feedId, modifiedTripId);
@@ -470,6 +470,8 @@ public class TimetableSnapshotSourceTest {
 
             assertEquals("New trip should not be found in scheduled time table", -1, newTimetableScheduled.getTripIndex(modifiedTripId));
         }
+
+         */
     }
 
     @Test


### PR DESCRIPTION
Do not use modified trip processing it trip matches but stops doesn't as it causes canceled trip to appear in indexes and replacement trip not added to indexes