### PR TITLE
Fixed an issue where Vertexconnectors would not log to taggedStopsLog

### DIFF
--- a/src/main/resources/logback.xml
+++ b/src/main/resources/logback.xml
@@ -84,5 +84,11 @@
   <logger name="org.opentripplanner.graph_builder.module.TransitToTaggedStopsModule" level="debug" additivity="false">
     <appender-ref ref="TaggedStopsLog"/>
   </logger>
+  <logger name="org.opentripplanner.graph_builder.module.HSLVertexConnector" level="debug" additivity="false">
+    <appender-ref ref="TaggedStopsLog"/>
+  </logger>
+  <logger name="org.opentripplanner.graph_builder.module.DefaultVertexConnector" level="debug" additivity="false">
+    <appender-ref ref="TaggedStopsLog"/>
+  </logger>
 
 </configuration>


### PR DESCRIPTION

This pull request fixes an issue where the taggedStopsLog was incomplete, VertexConnectors did not log there.