### PR TITLE
Downgrade jackson version to revert changes to null serialization in …

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -80,7 +80,8 @@
     <properties>
         <geotools.version>20.1</geotools.version>
         <geotools.wfs.version>16.5</geotools.wfs.version>
-        <jackson.version>2.9.7</jackson.version>
+        <!-- Upgrading jackson version might break serialization of null values for GraphQL output fields. -->
+        <jackson.version>2.8.11</jackson.version>
         <jersey.version>2.18</jersey.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <aws.version>1.11.456</aws.version>


### PR DESCRIPTION
Downgrade jackson version so that the null values are in  GraphQL similarly as before. After jackson was upgraded, field was  completely missing if value was "null". After this change it will behave  like before, in other words return field: null