### PR TITLE
Use unzip with overwrite to ease local development

### DIFF
--- a/run.sh
+++ b/run.sh
@@ -55,7 +55,8 @@ function download_graph {
   done
 
   if [ -f graph-$NAME.zip ]; then
-    unzip $GRAPH_FILE  -d ./graphs
+    # if the graph already exists then overwrite it, otherwise we need to build a new one on every start
+    unzip -o $GRAPH_FILE  -d ./graphs
     return $?;
   else
     return 1;


### PR DESCRIPTION
During local development I repeatedly start and stop the docker container. What happens is that the downloaded graph cannot be unpacked as the files already exits. This leads to complete rebuild of the graph, thereby forcing me to wait before I can start the actual development task.

By using the -o flag the existing, identical graph is overwritten when I start the container the second time.

To be completed by pull request submitter:

- [ ] **issue**: Link to or create an [issue](https://github.com/opentripplanner/OpenTripPlanner/issues) that describes the relevant feature or bug. Add [GitHub keywords](https://help.github.com/articles/closing-issues-using-keywords/) to this PR's description (e.g., `closes #45`).
- [ ] **roadmap**: Check the [roadmap](https://github.com/orgs/opentripplanner/projects/1) for this feature or bug. If it is not already on the roadmap, PLC will discuss as part of the review process.
- [ ] **tests**: Have you added relevant test coverage? Are all the tests passing on [the continuous integration service (Travis CI)](https://github.com/opentripplanner/OpenTripPlanner/blob/master/docs/Developers-Guide.md#continuous-integration)?
- [x] **formatting**: Have you followed the [suggested code style](https://github.com/opentripplanner/OpenTripPlanner/blob/master/docs/Developers-Guide.md#code-style)? 
- [x] **documentation**: If you are adding a new configuration option, have you added an explanation to the [configuration documentation](docs/Configuration.md) tables and sections?
- [ ] **changelog**: add a bullet point to the [changelog file](https://github.com/opentripplanner/OpenTripPlanner/blob/master/docs/Changelog.md) with description and link to the linked issue

To be completed by @opentripplanner/plc:

- [ ] reviews and approvals by 2 members, ideally from different organizations
- [ ] **after merging**: update the relevant card on the [roadmap](https://github.com/orgs/opentripplanner/projects/1)