### PR TITLE
Fix/optimize earlier than departure

### DIFF
--- a/src/main/java/org/opentripplanner/routing/edgetype/Timetable.java
+++ b/src/main/java/org/opentripplanner/routing/edgetype/Timetable.java
@@ -188,6 +188,9 @@ public class Timetable implements Serializable {
 
         boolean omitCanceled =  s0.getOptions().omitCanceled;
 
+        boolean isReverseOptimizing = s0.getOptions().reverseOptimizing;
+        int requestStartTime = serviceDay.secondsSinceMidnight(s0.getStartTimeSeconds());
+
         for (TripTimes tt : tripTimes) {
             if (tt.isCanceled() && omitCanceled) continue;
             if ((tt.getNumStops() <= stopIndex)) continue;
@@ -238,6 +241,7 @@ public class Timetable implements Serializable {
 
                 int arvTime = tt.getArrivalTime(stopIndex) + flexTimeAdjustment;
                 if (arvTime < 0) continue;
+                if (isReverseOptimizing && arvTime < requestStartTime) continue;
                 if (arvTime <= adjustedTime && arvTime > bestTime) {
                     bestTrip = tt;
                     bestTime = arvTime;

--- a/src/main/java/org/opentripplanner/routing/edgetype/Timetable.java
+++ b/src/main/java/org/opentripplanner/routing/edgetype/Timetable.java
@@ -189,7 +189,7 @@ public class Timetable implements Serializable {
         boolean omitCanceled =  s0.getOptions().omitCanceled;
 
         boolean isReverseOptimizing = s0.getOptions().reverseOptimizing;
-        int requestStartTime = serviceDay.secondsSinceMidnight(s0.getStartTimeSeconds());
+        int requestStartTime = serviceDay.secondsSinceMidnight(s0.getOptions().getSecondsSinceEpoch());
 
         for (TripTimes tt : tripTimes) {
             if (tt.isCanceled() && omitCanceled) continue;
@@ -241,7 +241,9 @@ public class Timetable implements Serializable {
 
                 int arvTime = tt.getArrivalTime(stopIndex) + flexTimeAdjustment;
                 if (arvTime < 0) continue;
-                if (isReverseOptimizing && arvTime < requestStartTime) continue;
+                if (isReverseOptimizing && arvTime < requestStartTime) {
+                    continue;
+                }
                 if (arvTime <= adjustedTime && arvTime > bestTime) {
                     bestTrip = tt;
                     bestTime = arvTime;


### PR DESCRIPTION
Fix a bug caused by reverse optimization that caused the routing to pick next trip without taking into account the actual request start time

To be completed by pull request submitter:

- [ ] **issue**: Link to or create an [issue](https://github.com/opentripplanner/OpenTripPlanner/issues) that describes the relevant feature or bug. Add [GitHub keywords](https://help.github.com/articles/closing-issues-using-keywords/) to this PR's description (e.g., `closes #45`).
- [ ] **roadmap**: Check the [roadmap](https://github.com/orgs/opentripplanner/projects/1) for this feature or bug. If it is not already on the roadmap, PLC will discuss as part of the review process.
- [ ] **tests**: Have you added relevant test coverage? Are all the tests passing on [the continuous integration service (Travis CI)](https://github.com/opentripplanner/OpenTripPlanner/blob/master/docs/Developers-Guide.md#continuous-integration)?
- [ ] **formatting**: Have you followed the [suggested code style](https://github.com/opentripplanner/OpenTripPlanner/blob/master/docs/Developers-Guide.md#code-style)? 
- [ ] **documentation**: If you are adding a new configuration option, have you added an explanation to the [configuration documentation](docs/Configuration.md) tables and sections?
- [ ] **changelog**: add a bullet point to the [changelog file](https://github.com/opentripplanner/OpenTripPlanner/blob/master/docs/Changelog.md) with description and link to the linked issue

To be completed by @opentripplanner/plc:

- [ ] reviews and approvals by 2 members, ideally from different organizations
- [ ] **after merging**: update the relevant card on the [roadmap](https://github.com/orgs/opentripplanner/projects/1)