### PR TITLE
Return null if leg doesn't have an route id

### DIFF
--- a/src/main/java/org/opentripplanner/index/IndexGraphQLSchema.java
+++ b/src/main/java/org/opentripplanner/index/IndexGraphQLSchema.java
@@ -3716,7 +3716,9 @@ public class IndexGraphQLSchema {
                         .type(agencyType)
                         .dataFetcher(environment -> {
                             Leg leg = environment.getSource();
-                            return index.getAgencyWithFeedScopeId(leg.routeId.getAgencyId() + ":" + leg.agencyId);
+                            if(leg.routeId != null) {
+                                return index.getAgencyWithFeedScopeId(leg.routeId.getAgencyId() + ":" + leg.agencyId);
+                            } else return null;
                         })
                         .build())
                 .field(GraphQLFieldDefinition.newFieldDefinition()


### PR DESCRIPTION
I pulled the latest changes into our repo and noticed a NPE when returning walking legs, as they don't have a route id/agency id.

This PR fixes it.