### PR TITLE
DT-4680 Add new fields to OTP that are needed on park and ride view

### DIFF
--- a/src/main/java/org/opentripplanner/index/IndexGraphQLSchema.java
+++ b/src/main/java/org/opentripplanner/index/IndexGraphQLSchema.java
@@ -2559,7 +2559,7 @@ public class IndexGraphQLSchema {
                         .build())
                 .field(GraphQLFieldDefinition.newFieldDefinition()
                         .name("tags")
-                        .description("Car park's services and authentication methods")
+                        .description("Additional information labels (tags) for the car park")
                         .type(new GraphQLList(GraphQLNonNull.nonNull(Scalars.GraphQLString)))
                         .dataFetcher(environment -> ((CarPark) environment.getSource()).tags)
                         .build())

--- a/src/main/java/org/opentripplanner/index/IndexGraphQLSchema.java
+++ b/src/main/java/org/opentripplanner/index/IndexGraphQLSchema.java
@@ -2448,6 +2448,12 @@ public class IndexGraphQLSchema {
                         .type(Scalars.GraphQLFloat)
                         .dataFetcher(environment -> ((BikePark) environment.getSource()).y)
                         .build())
+                .field(GraphQLFieldDefinition.newFieldDefinition()
+                        .name("tags")
+                        .description("Bike park's services and authentication methods")
+                        .type(new GraphQLList(GraphQLNonNull.nonNull(Scalars.GraphQLString)))
+                        .dataFetcher(environment -> ((BikePark) environment.getSource()).tags)
+                        .build())
                 .build();
 
         ticketType = GraphQLObjectType.newObject()

--- a/src/main/java/org/opentripplanner/index/IndexGraphQLSchema.java
+++ b/src/main/java/org/opentripplanner/index/IndexGraphQLSchema.java
@@ -2450,7 +2450,7 @@ public class IndexGraphQLSchema {
                         .build())
                 .field(GraphQLFieldDefinition.newFieldDefinition()
                         .name("tags")
-                        .description("Bike park's services and authentication methods")
+                        .description("Additional information labels (tags) for the Bike park")
                         .type(new GraphQLList(GraphQLNonNull.nonNull(Scalars.GraphQLString)))
                         .dataFetcher(environment -> ((BikePark) environment.getSource()).tags)
                         .build())

--- a/src/main/java/org/opentripplanner/index/IndexGraphQLSchema.java
+++ b/src/main/java/org/opentripplanner/index/IndexGraphQLSchema.java
@@ -2557,6 +2557,12 @@ public class IndexGraphQLSchema {
                         .type(Scalars.GraphQLFloat)
                         .dataFetcher(environment -> ((CarPark) environment.getSource()).y)
                         .build())
+                .field(GraphQLFieldDefinition.newFieldDefinition()
+                        .name("tags")
+                        .description("Car park's services and authentication methods")
+                        .type(new GraphQLList(GraphQLNonNull.nonNull(Scalars.GraphQLString)))
+                        .dataFetcher(environment -> ((CarPark) environment.getSource()).tags)
+                        .build())
                 .build();
 
         GraphQLInputObjectType filterInputType = GraphQLInputObjectType.newInputObject()

--- a/src/main/java/org/opentripplanner/routing/bike_park/BikePark.java
+++ b/src/main/java/org/opentripplanner/routing/bike_park/BikePark.java
@@ -1,6 +1,8 @@
 package org.opentripplanner.routing.bike_park;
 
 import java.io.Serializable;
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Locale;
 
 import javax.xml.bind.annotation.XmlAttribute;
@@ -38,6 +40,9 @@ public class BikePark implements Serializable {
     @XmlAttribute
     @JsonSerialize
     public boolean realTimeData = true;
+
+    @JsonSerialize
+    public List<String> tags;
 
     public boolean equals(Object o) {
         if (!(o instanceof BikePark)) {

--- a/src/main/java/org/opentripplanner/routing/car_park/CarPark.java
+++ b/src/main/java/org/opentripplanner/routing/car_park/CarPark.java
@@ -19,6 +19,8 @@ import org.opentripplanner.util.I18NString;
 
 import javax.xml.bind.annotation.XmlAttribute;
 import java.io.Serializable;
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Locale;
 
 
@@ -59,6 +61,9 @@ public class CarPark implements Serializable {
     public boolean realTimeData = true;
 
     public Geometry geometry;
+
+    @JsonSerialize
+    public List<String> tags;
 
     public boolean equals(Object o) {
         if (!(o instanceof CarPark)) {

--- a/src/main/java/org/opentripplanner/updater/bike_park/HslBikeParkDataSource.java
+++ b/src/main/java/org/opentripplanner/updater/bike_park/HslBikeParkDataSource.java
@@ -1,6 +1,10 @@
 package org.opentripplanner.updater.bike_park;
 
+import java.util.ArrayList;
+import java.util.List;
+
 import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.node.ArrayNode;
 import org.locationtech.jts.geom.Coordinate;
 import org.locationtech.jts.geom.Geometry;
 import org.locationtech.jts.geom.GeometryFactory;
@@ -43,6 +47,20 @@ public class HslBikeParkDataSource extends GenericJsonBikeParkDataSource{
             } else {
                 station.spacesAvailable = node.path("builtCapacity").path("BICYCLE").asInt();
             }
+            List<String> tags = new ArrayList<String>();
+            ArrayNode servicesArray = (ArrayNode) node.get("services");
+            if (servicesArray.isArray()) {
+                for (JsonNode jsonNode : servicesArray) {
+                    tags.add((String) jsonNode.asText());
+                }
+            }
+            ArrayNode authenticationMethods = (ArrayNode) node.get("authenticationMethods");
+            if (authenticationMethods.isArray()) {
+                for (JsonNode jsonNode : authenticationMethods) {
+                    tags.add((String) jsonNode.asText());
+                }
+            }
+            station.tags = tags;
             return station;
         } catch (Exception e) {
             log.warn("Error parsing bike rental station " + station.id, e);

--- a/src/main/java/org/opentripplanner/updater/bike_park/HslBikeParkDataSource.java
+++ b/src/main/java/org/opentripplanner/updater/bike_park/HslBikeParkDataSource.java
@@ -51,15 +51,16 @@ public class HslBikeParkDataSource extends GenericJsonBikeParkDataSource{
             ArrayNode servicesArray = (ArrayNode) node.get("services");
             if (servicesArray.isArray()) {
                 for (JsonNode jsonNode : servicesArray) {
-                    tags.add((String) jsonNode.asText());
+                    tags.add("SERVICE_" + jsonNode.asText());
                 }
             }
             ArrayNode authenticationMethods = (ArrayNode) node.get("authenticationMethods");
             if (authenticationMethods.isArray()) {
                 for (JsonNode jsonNode : authenticationMethods) {
-                    tags.add((String) jsonNode.asText());
+                    tags.add("AUTHENTICATION_METHOD_" + jsonNode.asText());
                 }
             }
+            tags.add("PRICING_METHOD_" + node.path("pricingMethod").asText());
             station.tags = tags;
             return station;
         } catch (Exception e) {

--- a/src/main/java/org/opentripplanner/updater/car_park/HslCarParkDataSource.java
+++ b/src/main/java/org/opentripplanner/updater/car_park/HslCarParkDataSource.java
@@ -70,15 +70,16 @@ public class HslCarParkDataSource extends GenericJsonCarParkDataSource{
             ArrayNode servicesArray = (ArrayNode) node.get("services");
             if (servicesArray.isArray()) {
                 for (JsonNode jsonNode : servicesArray) {
-                    tags.add((String) jsonNode.asText());
+                    tags.add("SERVICE_" + jsonNode.asText());
                 }
             }
             ArrayNode authenticationMethods = (ArrayNode) node.get("authenticationMethods");
             if (authenticationMethods.isArray()) {
                 for (JsonNode jsonNode : authenticationMethods) {
-                    tags.add((String) jsonNode.asText());
+                    tags.add("AUTHENTICATION_METHOD_" + jsonNode.asText());
                 }
             }
+            tags.add("PRICING_METHOD_" + node.path("pricingMethod").asText());
             station.tags = tags;
             return station;
         } catch (Exception e) {

--- a/src/main/java/org/opentripplanner/updater/car_park/HslCarParkDataSource.java
+++ b/src/main/java/org/opentripplanner/updater/car_park/HslCarParkDataSource.java
@@ -3,6 +3,7 @@ package org.opentripplanner.updater.car_park;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ArrayNode;
 import org.locationtech.jts.geom.Coordinate;
 import org.locationtech.jts.geom.Geometry;
 import org.locationtech.jts.geom.GeometryFactory;
@@ -18,8 +19,10 @@ import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
 import java.io.InputStream;
+import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 
@@ -63,6 +66,20 @@ public class HslCarParkDataSource extends GenericJsonCarParkDataSource{
             } else {
                 station.spacesAvailable = station.maxCapacity;
             }
+            List<String> tags = new ArrayList<String>();
+            ArrayNode servicesArray = (ArrayNode) node.get("services");
+            if (servicesArray.isArray()) {
+                for (JsonNode jsonNode : servicesArray) {
+                    tags.add((String) jsonNode.asText());
+                }
+            }
+            ArrayNode authenticationMethods = (ArrayNode) node.get("authenticationMethods");
+            if (authenticationMethods.isArray()) {
+                for (JsonNode jsonNode : authenticationMethods) {
+                    tags.add((String) jsonNode.asText());
+                }
+            }
+            station.tags = tags;
             return station;
         } catch (Exception e) {
             log.warn("Error parsing car park " + station.id, e);


### PR DESCRIPTION
Parse services, authenticationMethods and pricingMethod from park and ride API into a new tags field for bike and car parks that are exposed in GraphQL and REST api. Prefix is added to the values based on from which field from the API the values are read from.