### PR TITLE
DT 5062 Add openingHours to bike and car parks

### DIFF
--- a/src/main/java/org/opentripplanner/common/LocalTimeSpan.java
+++ b/src/main/java/org/opentripplanner/common/LocalTimeSpan.java
@@ -1,0 +1,27 @@
+package org.opentripplanner.common;
+
+/**
+ * Represents a time span.
+ *
+ */
+public class LocalTimeSpan {
+
+    /**
+    * Seconds from midnight.
+    */
+    public int from;
+
+    /**
+    * Seconds from midnight.
+    */
+    public int to;
+    
+    public LocalTimeSpan(int from, int to) {
+        this.from = from;
+        this.to = to;
+    }
+
+    public String toString() {
+        return String.format("from %s to %s", from, to);
+    }
+}

--- a/src/main/java/org/opentripplanner/common/LocalTimeSpanDate.java
+++ b/src/main/java/org/opentripplanner/common/LocalTimeSpanDate.java
@@ -1,0 +1,31 @@
+package org.opentripplanner.common;
+
+import java.util.ArrayList;
+
+/**
+ * Represents a date that contains a list of time spans.
+ */
+public class LocalTimeSpanDate {
+
+    /**
+    * Date in YYYYMMDD format.
+    */
+    public String date;
+
+    public ArrayList<LocalTimeSpan> localTimeSpans;
+    
+    public LocalTimeSpanDate(String date) {
+        this.date = date;
+    }
+
+    public void addSpans(ArrayList<LocalTimeSpan> timeSpans) {
+        if (localTimeSpans == null) {
+            localTimeSpans = new ArrayList<LocalTimeSpan>();
+        }
+        this.localTimeSpans.addAll(timeSpans);
+    }
+
+    public String toString() {
+        return String.format("%s time spans exist for %s", localTimeSpans == null ? 0 : localTimeSpans.size(), date);
+    }
+}

--- a/src/main/java/org/opentripplanner/common/LocalTimeSpanWeek.java
+++ b/src/main/java/org/opentripplanner/common/LocalTimeSpanWeek.java
@@ -1,0 +1,38 @@
+package org.opentripplanner.common;
+
+import java.util.ArrayList;
+
+/**
+ * Represents a week that contains days or day types with time spans.
+ */
+public class LocalTimeSpanWeek {
+
+    public enum DayType {
+        BUSINESS_DAY, SATURDAY, SUNDAY;
+    }
+
+    public ArrayList<LocalTimeSpan> businessDayTimeSpans;
+
+    public ArrayList<LocalTimeSpan> saturdayTimeSpans;
+
+    public ArrayList<LocalTimeSpan> sundayTimeSpans;
+
+    public void addSpan(DayType dayType, LocalTimeSpan timeSpan) {
+        if (dayType == DayType.BUSINESS_DAY) {
+            if (businessDayTimeSpans == null) {
+                businessDayTimeSpans = new ArrayList<LocalTimeSpan>();
+            }
+            businessDayTimeSpans.add(timeSpan);
+        } else if (dayType == DayType.SATURDAY) {
+            if (saturdayTimeSpans == null) {
+                saturdayTimeSpans = new ArrayList<LocalTimeSpan>();
+            }
+            saturdayTimeSpans.add(timeSpan);
+        } else if (dayType == DayType.SUNDAY) {
+            if (sundayTimeSpans == null) {
+                sundayTimeSpans = new ArrayList<LocalTimeSpan>();
+            }
+            sundayTimeSpans.add(timeSpan);
+        }
+    }
+}

--- a/src/main/java/org/opentripplanner/index/IndexGraphQLSchema.java
+++ b/src/main/java/org/opentripplanner/index/IndexGraphQLSchema.java
@@ -13,6 +13,8 @@ import org.opentripplanner.api.common.Message;
 import org.opentripplanner.api.model.*;
 import org.opentripplanner.api.parameter.QualifiedMode;
 import org.opentripplanner.api.parameter.QualifiedModeSet;
+import org.opentripplanner.common.LocalTimeSpan;
+import org.opentripplanner.common.LocalTimeSpanDate;
 import org.opentripplanner.common.model.P2;
 import org.opentripplanner.gtfs.GtfsLibrary;
 import org.opentripplanner.index.model.StopTimesInPattern;
@@ -261,6 +263,10 @@ public class IndexGraphQLSchema {
     public GraphQLObjectType queryType;
 
     public GraphQLOutputType planType = new GraphQLTypeReference("Plan");
+
+    public GraphQLOutputType localTimeSpanType = new GraphQLTypeReference("LocalTimeSpan");
+
+    public GraphQLOutputType localTimeSpanDateType = new GraphQLTypeReference("LocalTimeSpanDate");
 
     public GraphQLSchema indexSchema;
 
@@ -2400,6 +2406,40 @@ public class IndexGraphQLSchema {
                         .build())
                 .build();
 
+        localTimeSpanType = GraphQLObjectType.newObject()
+                .name("LocalTimeSpan")
+                .description("A span of time.")
+                .field(GraphQLFieldDefinition.newFieldDefinition()
+                        .name("from")
+                        .description("The start of the time timespan as seconds from midnight.")
+                        .type(new GraphQLNonNull(Scalars.GraphQLInt))
+                        .dataFetcher(environment -> ((LocalTimeSpan) environment.getSource()).from)
+                        .build())
+                .field(GraphQLFieldDefinition.newFieldDefinition()
+                        .name("to")
+                        .description("The end of the timespan as seconds from midnight.")
+                        .type(new GraphQLNonNull(Scalars.GraphQLInt))
+                        .dataFetcher(environment -> ((LocalTimeSpan) environment.getSource()).to)
+                        .build())
+                .build();
+
+        localTimeSpanDateType = GraphQLObjectType.newObject()
+                .name("LocalTimeSpanDate")
+                .description("A date using the local timezone of the object that can contain timespans.")
+                .field(GraphQLFieldDefinition.newFieldDefinition()
+                        .name("timeSpans")
+                        .description("The time spans for this date.")
+                        .type(new GraphQLList(localTimeSpanType))
+                        .dataFetcher(environment -> ((LocalTimeSpanDate) environment.getSource()).localTimeSpans)
+                        .build())
+                .field(GraphQLFieldDefinition.newFieldDefinition()
+                        .name("date")
+                        .description("The date of this time span. Format: YYYYMMDD.")
+                        .type(new GraphQLNonNull(Scalars.GraphQLString))
+                        .dataFetcher(environment -> ((LocalTimeSpanDate) environment.getSource()).date)
+                        .build())
+                .build();
+
         bikeParkType = GraphQLObjectType.newObject()
                 .name("BikePark")
                 .description("Bike park represents a location where bicycles can be parked.")
@@ -2453,6 +2493,21 @@ public class IndexGraphQLSchema {
                         .description("Additional information labels (tags) for the Bike park")
                         .type(new GraphQLList(Scalars.GraphQLString))
                         .dataFetcher(environment -> ((BikePark) environment.getSource()).tags)
+                        .build())
+                .field(GraphQLFieldDefinition.newFieldDefinition()
+                        .name("openingHours")
+                        .description("Opening hours for the selected dates using the local time of the park. Each date can have multiple time spans.")
+                        .type(new GraphQLList(localTimeSpanDateType))
+                        .argument(GraphQLArgument.newArgument()
+                                .name("dates")
+                                .description("Opening hours will be returned for these dates. Dates should use YYYYMMDD format")
+                                .type(new GraphQLNonNull(new GraphQLList(new GraphQLNonNull(Scalars.GraphQLString)))))
+                        .dataFetcher(environment -> {
+                                if (environment.getArgument("dates") instanceof List) {
+                                        return ((BikePark) environment.getSource()).getOpeningHoursForDates(environment.getArgument("dates"));
+                                }
+                                return new ArrayList<String>();
+                        })
                         .build())
                 .build();
 
@@ -2562,6 +2617,21 @@ public class IndexGraphQLSchema {
                         .description("Additional information labels (tags) for the car park")
                         .type(new GraphQLList(Scalars.GraphQLString))
                         .dataFetcher(environment -> ((CarPark) environment.getSource()).tags)
+                        .build())
+                .field(GraphQLFieldDefinition.newFieldDefinition()
+                        .name("openingHours")
+                        .description("Opening hours for the selected dates using the local time of the park. Each date can have multiple time spans.")
+                        .type(new GraphQLList(localTimeSpanDateType))
+                        .argument(GraphQLArgument.newArgument()
+                                .name("dates")
+                                .description("Opening hours will be returned for these dates. Dates should use YYYYMMDD format")
+                                .type(new GraphQLNonNull(new GraphQLList(new GraphQLNonNull(Scalars.GraphQLString)))))
+                        .dataFetcher(environment -> {
+                                if (environment.getArgument("dates") instanceof List) {
+                                        return ((CarPark) environment.getSource()).getOpeningHoursForDates(environment.getArgument("dates"));
+                                }
+                                return new ArrayList<String>();
+                        })
                         .build())
                 .build();
 

--- a/src/main/java/org/opentripplanner/index/IndexGraphQLSchema.java
+++ b/src/main/java/org/opentripplanner/index/IndexGraphQLSchema.java
@@ -2451,7 +2451,7 @@ public class IndexGraphQLSchema {
                 .field(GraphQLFieldDefinition.newFieldDefinition()
                         .name("tags")
                         .description("Additional information labels (tags) for the Bike park")
-                        .type(new GraphQLList(GraphQLNonNull.nonNull(Scalars.GraphQLString)))
+                        .type(new GraphQLList(Scalars.GraphQLString))
                         .dataFetcher(environment -> ((BikePark) environment.getSource()).tags)
                         .build())
                 .build();
@@ -2560,7 +2560,7 @@ public class IndexGraphQLSchema {
                 .field(GraphQLFieldDefinition.newFieldDefinition()
                         .name("tags")
                         .description("Additional information labels (tags) for the car park")
-                        .type(new GraphQLList(GraphQLNonNull.nonNull(Scalars.GraphQLString)))
+                        .type(new GraphQLList(Scalars.GraphQLString))
                         .dataFetcher(environment -> ((CarPark) environment.getSource()).tags)
                         .build())
                 .build();

--- a/src/main/java/org/opentripplanner/routing/bike_park/BikePark.java
+++ b/src/main/java/org/opentripplanner/routing/bike_park/BikePark.java
@@ -1,6 +1,9 @@
 package org.opentripplanner.routing.bike_park;
 
 import java.io.Serializable;
+import java.time.DayOfWeek;
+import java.time.LocalDate;
+import java.time.format.DateTimeFormatter;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Locale;
@@ -8,6 +11,10 @@ import java.util.Locale;
 import javax.xml.bind.annotation.XmlAttribute;
 
 import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+
+import org.opentripplanner.common.LocalTimeSpan;
+import org.opentripplanner.common.LocalTimeSpanDate;
+import org.opentripplanner.common.LocalTimeSpanWeek;
 
 public class BikePark implements Serializable {
     private static final long serialVersionUID = 8311460609708089384L;
@@ -42,6 +49,49 @@ public class BikePark implements Serializable {
     public boolean realTimeData = true;
 
     public List<String> tags;
+
+    /**
+     * Contains opening hours for business days, saturday and sunday,
+     * where all times are seconds from midnight.
+     */
+    public LocalTimeSpanWeek openingHours;
+
+    /**
+     * Dates should be in the format of YYYYMMDD, returns a {@link LocalTimeSpanDate} for each date.
+     */
+    public ArrayList<LocalTimeSpanDate> getOpeningHoursForDates(List<String> dates) {
+        ArrayList<LocalTimeSpanDate> timeSpanDates = new ArrayList<LocalTimeSpanDate>();
+        for (int i = 0; i < dates.size(); i++) {
+            String date = dates.get(i);
+            if (date.length() != 8) {
+                timeSpanDates.add(null);
+                continue;
+            }
+            LocalDate localDate = LocalDate.parse(date, DateTimeFormatter.BASIC_ISO_DATE);
+            DayOfWeek dayOfWeek = localDate.getDayOfWeek();
+            LocalTimeSpanDate timeSpanDate = new LocalTimeSpanDate(date);
+            if (openingHours != null) {
+                if (dayOfWeek == DayOfWeek.SUNDAY) {
+                    ArrayList<LocalTimeSpan> openingHoursForSunday = openingHours.sundayTimeSpans;
+                    if (openingHoursForSunday != null) {
+                        timeSpanDate.addSpans(openingHoursForSunday);
+                    }
+                } else if (dayOfWeek == DayOfWeek.SATURDAY) {
+                    ArrayList<LocalTimeSpan> openingHoursForSaturday = openingHours.saturdayTimeSpans;
+                    if (openingHoursForSaturday != null) {
+                        timeSpanDate.addSpans(openingHoursForSaturday);
+                    }
+                } else {
+                    ArrayList<LocalTimeSpan> openingHoursForBusinessDays = openingHours.businessDayTimeSpans;
+                    if (openingHoursForBusinessDays != null) {
+                        timeSpanDate.addSpans(openingHoursForBusinessDays);
+                    }
+                }
+            }
+            timeSpanDates.add(timeSpanDate);
+        }
+        return timeSpanDates;
+    }
 
     public boolean equals(Object o) {
         if (!(o instanceof BikePark)) {

--- a/src/main/java/org/opentripplanner/routing/bike_park/BikePark.java
+++ b/src/main/java/org/opentripplanner/routing/bike_park/BikePark.java
@@ -41,7 +41,6 @@ public class BikePark implements Serializable {
     @JsonSerialize
     public boolean realTimeData = true;
 
-    @JsonSerialize
     public List<String> tags;
 
     public boolean equals(Object o) {

--- a/src/main/java/org/opentripplanner/routing/car_park/CarPark.java
+++ b/src/main/java/org/opentripplanner/routing/car_park/CarPark.java
@@ -15,10 +15,16 @@ package org.opentripplanner.routing.car_park;
 
 import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 import org.locationtech.jts.geom.Geometry;
+import org.opentripplanner.common.LocalTimeSpan;
+import org.opentripplanner.common.LocalTimeSpanDate;
+import org.opentripplanner.common.LocalTimeSpanWeek;
 import org.opentripplanner.util.I18NString;
 
 import javax.xml.bind.annotation.XmlAttribute;
 import java.io.Serializable;
+import java.time.DayOfWeek;
+import java.time.LocalDate;
+import java.time.format.DateTimeFormatter;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Locale;
@@ -63,6 +69,49 @@ public class CarPark implements Serializable {
     public Geometry geometry;
 
     public List<String> tags;
+
+    /**
+     * Contains opening hours for business days, saturday and sunday,
+     * where all times are seconds from midnight.
+     */
+    public LocalTimeSpanWeek openingHours;
+
+    /**
+     * Dates should be in the format of YYYYMMDD, returns a {@link LocalTimeSpanDate} for each date.
+     */
+    public ArrayList<LocalTimeSpanDate> getOpeningHoursForDates(List<String> dates) {
+        ArrayList<LocalTimeSpanDate> timeSpanDates = new ArrayList<LocalTimeSpanDate>();
+        for (int i = 0; i < dates.size(); i++) {
+            String date = dates.get(i);
+            if (date.length() != 8) {
+                timeSpanDates.add(null);
+                continue;
+            }
+            LocalDate localDate = LocalDate.parse(date, DateTimeFormatter.BASIC_ISO_DATE);
+            DayOfWeek dayOfWeek = localDate.getDayOfWeek();
+            LocalTimeSpanDate timeSpanDate = new LocalTimeSpanDate(date);
+            if (openingHours != null) {
+                if (dayOfWeek == DayOfWeek.SUNDAY) {
+                    ArrayList<LocalTimeSpan> openingHoursForSunday = openingHours.sundayTimeSpans;
+                    if (openingHoursForSunday != null) {
+                        timeSpanDate.addSpans(openingHoursForSunday);
+                    }
+                } else if (dayOfWeek == DayOfWeek.SATURDAY) {
+                    ArrayList<LocalTimeSpan> openingHoursForSaturday = openingHours.saturdayTimeSpans;
+                    if (openingHoursForSaturday != null) {
+                        timeSpanDate.addSpans(openingHoursForSaturday);
+                    }
+                } else {
+                    ArrayList<LocalTimeSpan> openingHoursForBusinessDays = openingHours.businessDayTimeSpans;
+                    if (openingHoursForBusinessDays != null) {
+                        timeSpanDate.addSpans(openingHoursForBusinessDays);
+                    }
+                }
+            }
+            timeSpanDates.add(timeSpanDate);
+        }
+        return timeSpanDates;
+    }
 
     public boolean equals(Object o) {
         if (!(o instanceof CarPark)) {

--- a/src/main/java/org/opentripplanner/routing/car_park/CarPark.java
+++ b/src/main/java/org/opentripplanner/routing/car_park/CarPark.java
@@ -62,7 +62,6 @@ public class CarPark implements Serializable {
 
     public Geometry geometry;
 
-    @JsonSerialize
     public List<String> tags;
 
     public boolean equals(Object o) {

--- a/src/main/java/org/opentripplanner/updater/car_park/HslCarParkDataSource.java
+++ b/src/main/java/org/opentripplanner/updater/car_park/HslCarParkDataSource.java
@@ -10,6 +10,8 @@ import org.locationtech.jts.geom.GeometryFactory;
 import org.locationtech.jts.geom.LineString;
 import org.locationtech.jts.geom.LinearRing;
 import org.locationtech.jts.geom.Polygon;
+import org.opentripplanner.common.LocalTimeSpan;
+import org.opentripplanner.common.LocalTimeSpanWeek;
 import org.opentripplanner.routing.car_park.CarPark;
 import org.opentripplanner.routing.graph.Graph;
 import org.opentripplanner.util.HttpUtils;
@@ -81,11 +83,53 @@ public class HslCarParkDataSource extends GenericJsonCarParkDataSource{
             }
             tags.add("PRICING_METHOD_" + node.path("pricingMethod").asText());
             station.tags = tags;
+
+            LocalTimeSpanWeek timeSpanWeek = new LocalTimeSpanWeek();
+            JsonNode openDayHours = node.path("openingHours").path("byDayType");
+            if (openDayHours.has("BUSINESS_DAY") && openDayHours.path("BUSINESS_DAY").has("from")) {
+                timeSpanWeek.addSpan(
+                    LocalTimeSpanWeek.DayType.BUSINESS_DAY,
+                    convertOpeningHoursToLocalTimeSpan(openDayHours.path("BUSINESS_DAY"))
+                );
+            }
+            if (openDayHours.has("SATURDAY") && openDayHours.path("SATURDAY").has("from")) {
+                timeSpanWeek.addSpan(
+                    LocalTimeSpanWeek.DayType.SATURDAY,
+                    convertOpeningHoursToLocalTimeSpan(openDayHours.path("SATURDAY"))
+                );
+            }
+            if (openDayHours.has("SUNDAY") && openDayHours.path("SUNDAY").has("from")) {
+                timeSpanWeek.addSpan(
+                    LocalTimeSpanWeek.DayType.SUNDAY,
+                    convertOpeningHoursToLocalTimeSpan(openDayHours.path("SUNDAY"))
+                );
+            }
+
+            station.openingHours = timeSpanWeek;
+
             return station;
         } catch (Exception e) {
             log.warn("Error parsing car park " + station.id, e);
             return null;
         }
+    }
+
+    /**
+     * Parses a {@link LocalTimeSpan} from an openingHour definition for a day type.
+     * The times can either have just hours or hours:minutes.
+     */
+    private LocalTimeSpan convertOpeningHoursToLocalTimeSpan(JsonNode dayHours) {
+        String from = dayHours.path("from").asText();
+        int fromSecondsFromMidnight = Integer.parseInt(from.substring(0, 2)) * 60 * 60;
+        if (from.length() > 2) {
+            fromSecondsFromMidnight += Integer.parseInt(from.substring(3, 5)) * 60;
+        }
+        String to = dayHours.path("until").asText();
+        int toSecondsFromMidnight = Integer.parseInt(to.substring(0, 2)) * 60 * 60;
+        if (to.length() > 2) {
+            toSecondsFromMidnight += Integer.parseInt(to.substring(3, 5)) * 60;
+        }
+        return new LocalTimeSpan(fromSecondsFromMidnight, toSecondsFromMidnight);
     }
 
     public boolean update() {


### PR DESCRIPTION
* Updates hsl park&ride updaters to parse openingHours into car and bike parks
* Expose the openingHours through graphql API so they can be fetched for dates
* Change so tag can be null and don't expose it through REST api

<b>Note, we could use this information in routing as well but then we would have to take into account time zones</b>