### PR TITLE
Do not reject shape geometry when shape_dist_traveled is incorrect

### DIFF
--- a/src/main/java/org/opentripplanner/routing/edgetype/factory/PatternHopFactory.java
+++ b/src/main/java/org/opentripplanner/routing/edgetype/factory/PatternHopFactory.java
@@ -591,14 +591,21 @@ public class PatternHopFactory {
         // Detect presence or absence of shape_dist_traveled on a per-trip basis
         StopTime st0 = stopTimes.get(0);
         boolean hasShapeDist = st0.isShapeDistTraveledSet();
+        int hopCount = stopTimes.size() - 1;
         if (hasShapeDist) {
             // this trip has shape_dist in stop_times
-            for (int i = 0; i < stopTimes.size() - 1; ++i) {
+            for (int i = 0; i < hopCount; ++i) {
                 st0 = stopTimes.get(i);
                 StopTime st1 = stopTimes.get(i + 1);
                 geoms[i] = getHopGeometryViaShapeDistTraveled(graph, shapeId, st0, st1);
+                if (!geoms[i]) {
+                    break;
+                }
             }
-            return geoms;
+            if (i>=hopCount) {
+                return geoms;
+            }
+            // else proceed to method which ignores shape_dist_traveled
         }
         LineString shape = getLineStringForShapeId(shapeId);
         if (shape == null) {
@@ -1093,8 +1100,7 @@ public class PatternHopFactory {
 
             if (equals(startIndex, endIndex)) {
                 //bogus shape_dist_traveled
-                graph.addBuilderAnnotation(new BogusShapeDistanceTraveled(st1));
-                return createSimpleGeometry(st0.getStop(), st1.getStop());
+                return null;
             }
             LineString line = getLineStringForShapeId(shapeId);
             LocationIndexedLine lol = new LocationIndexedLine(line);

--- a/src/main/java/org/opentripplanner/routing/edgetype/factory/PatternHopFactory.java
+++ b/src/main/java/org/opentripplanner/routing/edgetype/factory/PatternHopFactory.java
@@ -598,11 +598,11 @@ public class PatternHopFactory {
                 st0 = stopTimes.get(i);
                 StopTime st1 = stopTimes.get(i + 1);
                 geoms[i] = getHopGeometryViaShapeDistTraveled(graph, shapeId, st0, st1);
-                if (!geoms[i]) {
+                if (geoms[i] == null) {
                     break;
                 }
             }
-            if (i>=hopCount) {
+            if (i >= hopCount) {
                 return geoms;
             }
             // else proceed to method which ignores shape_dist_traveled

--- a/src/main/java/org/opentripplanner/routing/edgetype/factory/PatternHopFactory.java
+++ b/src/main/java/org/opentripplanner/routing/edgetype/factory/PatternHopFactory.java
@@ -593,8 +593,9 @@ public class PatternHopFactory {
         boolean hasShapeDist = st0.isShapeDistTraveledSet();
         int hopCount = stopTimes.size() - 1;
         if (hasShapeDist) {
+	    int i;
             // this trip has shape_dist in stop_times
-            for (int i = 0; i < hopCount; ++i) {
+            for (i = 0; i < hopCount; ++i) {
                 st0 = stopTimes.get(i);
                 StopTime st1 = stopTimes.get(i + 1);
                 geoms[i] = getHopGeometryViaShapeDistTraveled(graph, shapeId, st0, st1);


### PR DESCRIPTION
If shape_dist_traveled of stop_times does not match provided shape geoometry, ignore only shape_dist_traveled, not the shape geometry. 
 