### PR TITLE
TransitModeMapper route type 8

### DIFF
--- a/src/main/java/org/opentripplanner/gtfs/mapping/TransitModeMapper.java
+++ b/src/main/java/org/opentripplanner/gtfs/mapping/TransitModeMapper.java
@@ -70,6 +70,7 @@ public class TransitModeMapper {
       case 5 -> TransitMode.CABLE_CAR;
       case 6 -> TransitMode.GONDOLA;
       case 7 -> TransitMode.FUNICULAR;
+      case 8 -> TransitMode.AIRPLANE;
       case 11 -> TransitMode.TROLLEYBUS;
       case 12 -> TransitMode.MONORAIL;
       default -> throw new IllegalArgumentException("unknown gtfs route type " + routeType);


### PR DESCRIPTION
Hello,
I'm submitting this pull request since some GTFS use the route type 8 for air planes.

Proof with **KorriGo**, the french brittany transport company : https://www.korrigo.bzh/ftp/OPENDATA/KORRIGOBRET.gtfs.zip

![image](https://github.com/user-attachments/assets/d9a7ab11-dd98-430a-bc99-1a2ccaabf686)